### PR TITLE
Fix flaky test and orchestrator logic

### DIFF
--- a/py-load-epar/tests/etl/test_orchestrator.py
+++ b/py-load-epar/tests/etl/test_orchestrator.py
@@ -81,7 +81,11 @@ def test_run_etl_successful_flow(
     assert mock_process_substances.call_count == 2
     mock_process_substances.assert_any_call(mock_adapter, ["sub1"])
     mock_process_links.assert_called_once_with(mock_adapter, substance_links)
-    assert mock_process_docs.call_count == 2
+    mock_process_docs.assert_called_once_with(
+        adapter=mock_adapter,
+        processed_records=[record1, record2],
+        storage=mock_storage_instance,
+    )
     mock_adapter.close.assert_called_once()
 
 


### PR DESCRIPTION
- Refactored the flaky end-to-end test `test_document_processing_and_retry` to be more robust and reliable.
  - Removed the dependency on `requests-mock` for the download part and used a higher-level mock on `download_document_and_hash` to avoid complex interactions between mocking libraries.
  - Made the test self-contained by creating its own test data.
  - Used an absolute path for the local storage to fix a bug in the test setup.
- Fixed a bug in the ETL orchestrator where document processing was happening before the main data was loaded, which could lead to foreign key violations.
- Updated the unit tests for the orchestrator to reflect the change in logic.